### PR TITLE
fix: LogReturn export

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4,5 +4,5 @@ import { LogReturn, Metadata, LogLevel, LogLevelWithOk, Colors } from "./types/l
 import { cleanLogString, cleanSpyLogs } from "./utils";
 import { LOG_LEVEL, COLORS } from "./constants";
 
-export type { LogReturn, Metadata, LogLevel, LogLevelWithOk, Colors };
-export { Logs, PrettyLogs, cleanLogString, cleanSpyLogs, LOG_LEVEL, COLORS };
+export type { Metadata, LogLevel, LogLevelWithOk, Colors };
+export { Logs, PrettyLogs, LogReturn, cleanLogString, cleanSpyLogs, LOG_LEVEL, COLORS };


### PR DESCRIPTION
`LogReturn` was exported via `export type` and so TS was able to pickup the class through imports but as it's a class object and not a type runtime imports would fail because it was never exported as such.

my first approval-less merge considering the change made