### PR TITLE
fix: always return a LogReturn instead of null

### DIFF
--- a/src/logs.ts
+++ b/src/logs.ts
@@ -6,11 +6,12 @@ export class Logs {
   private _maxLevel = -1;
   static console: PrettyLogs;
 
-  private _log({ level, consoleLog, logMessage, metadata, type }: LogParams): LogReturn | null {
+  private _log({ level, consoleLog, logMessage, metadata, type }: LogParams): LogReturn {
     // filter out more verbose logs according to maxLevel set in config
-    if (this._getNumericLevel(level) > this._maxLevel) return null;
+    if (this._getNumericLevel(level) < this._maxLevel) {
+      consoleLog(logMessage, metadata);
+    }
 
-    consoleLog(logMessage, metadata);
     return new LogReturn(
       {
         raw: logMessage,

--- a/src/logs.ts
+++ b/src/logs.ts
@@ -46,7 +46,7 @@ export class Logs {
     return metadata;
   }
 
-  public ok(log: string, metadata?: Metadata): LogReturn | null {
+  public ok(log: string, metadata?: Metadata): LogReturn {
     metadata = this._addDiagnosticInformation(metadata);
     return this._log({
       level: LOG_LEVEL.INFO,
@@ -57,7 +57,7 @@ export class Logs {
     });
   }
 
-  public info(log: string, metadata?: Metadata): LogReturn | null {
+  public info(log: string, metadata?: Metadata): LogReturn {
     metadata = this._addDiagnosticInformation(metadata);
     return this._log({
       level: LOG_LEVEL.INFO,
@@ -68,7 +68,7 @@ export class Logs {
     });
   }
 
-  public error(log: string, metadata?: Metadata): LogReturn | null {
+  public error(log: string, metadata?: Metadata): LogReturn {
     metadata = this._addDiagnosticInformation(metadata);
     return this._log({
       level: LOG_LEVEL.ERROR,
@@ -79,7 +79,7 @@ export class Logs {
     });
   }
 
-  public debug(log: string, metadata?: Metadata): LogReturn | null {
+  public debug(log: string, metadata?: Metadata): LogReturn {
     metadata = this._addDiagnosticInformation(metadata);
     return this._log({
       level: LOG_LEVEL.DEBUG,
@@ -90,7 +90,7 @@ export class Logs {
     });
   }
 
-  public fatal(log: string, metadata?: Metadata): LogReturn | null {
+  public fatal(log: string, metadata?: Metadata): LogReturn {
     if (!metadata) {
       metadata = Logs.convertErrorsIntoObjects(new Error(log)) as Metadata;
       const stack = metadata.stack as string[];
@@ -115,7 +115,7 @@ export class Logs {
     });
   }
 
-  public verbose(log: string, metadata?: Metadata): LogReturn | null {
+  public verbose(log: string, metadata?: Metadata): LogReturn {
     metadata = this._addDiagnosticInformation(metadata);
     return this._log({
       level: LOG_LEVEL.VERBOSE,

--- a/src/logs.ts
+++ b/src/logs.ts
@@ -8,7 +8,7 @@ export class Logs {
 
   private _log({ level, consoleLog, logMessage, metadata, type }: LogParams): LogReturn {
     // filter out more verbose logs according to maxLevel set in config
-    if (this._getNumericLevel(level) < this._maxLevel) {
+    if (this._getNumericLevel(level) <= this._maxLevel) {
       consoleLog(logMessage, metadata);
     }
 


### PR DESCRIPTION
I'm tired of having to cast our `logMessage.diff` and optionally accessing our `LogReturn` objects from the logger

I have reversed the boolean logic here so that we log instead of returning null and so we can always return a `logReturn` object