### PR TITLE
fix: fixed logger console output

### DIFF
--- a/.github/workflows/sync-template.yml
+++ b/.github/workflows/sync-template.yml
@@ -3,7 +3,7 @@ name: Sync branch to template
 on:
   workflow_dispatch:
   schedule:
-    - cron: '14 0 1 * *'
+    - cron: "14 0 1 * *"
 
 jobs:
   sync:
@@ -23,7 +23,7 @@ jobs:
         with:
           app_id: ${{ secrets.APP_ID }}
           private_key: ${{ secrets.APP_PRIVATE_KEY }}
-  
+
       - name: Sync branch to template
         env:
           GH_TOKEN: ${{ steps.get_installation_token.outputs.token }}
@@ -45,5 +45,3 @@ jobs:
           git commit -m "chore: sync template"
           git push "$original_remote" "$pr_branch"
           gh pr create --title "Sync branch to template" --body "This pull request merges changes from the template repository." --head "$pr_branch" --base "$branch_name"
-
-          

--- a/src/pretty-logs.ts
+++ b/src/pretty-logs.ts
@@ -40,43 +40,38 @@ export class PrettyLogs {
   }
 
   private _logWithStack(type: LogLevelWithOk, message: string, metaData?: Metadata | string | unknown) {
-    this._log(type, message);
+    let stack = "";
+    let metadataFormatted = "";
+
     if (typeof metaData === "string") {
-      this._log(type, metaData);
-      return;
-    }
-    if (metaData) {
+      metadataFormatted = `\n${metaData}`;
+    } else if (metaData) {
       const metadata = metaData as Metadata;
-      let stack = metadata?.error?.stack || metadata?.stack;
-      if (!stack) {
-        // generate and remove the top four lines of the stack trace
+      stack = (metadata?.error?.stack || metadata?.stack || "") as string;
+
+      if (!stack || typeof stack !== "string") {
         const stackTrace = new Error().stack?.split("\n");
         if (stackTrace) {
           stackTrace.splice(0, 4);
           stack = stackTrace.filter((line) => line.includes(".ts:")).join("\n");
+        } else {
+          stack = "";
         }
       }
+
       const newMetadata = { ...metadata };
       delete newMetadata.message;
       delete newMetadata.name;
       delete newMetadata.stack;
 
       if (!this._isEmpty(newMetadata)) {
-        this._log(type, newMetadata);
-      }
-
-      if (typeof stack == "string") {
-        const prettyStack = this._formatStackTrace(stack, 1);
-        const colorizedStack = this._colorizeText(prettyStack, COLORS.dim);
-        this._log(type, colorizedStack);
-      } else if (stack) {
-        const prettyStack = this._formatStackTrace((stack as unknown as string[]).join("\n"), 1);
-        const colorizedStack = this._colorizeText(prettyStack, COLORS.dim);
-        this._log(type, colorizedStack);
-      } else {
-        throw new Error("Stack is null");
+        metadataFormatted = `\n${JSON.stringify(newMetadata, null, 2)}`;
       }
     }
+
+    const finalLogMessage = [message, metadataFormatted, stack ? `\n${stack}` : ""].filter(Boolean).join("\n").trim();
+
+    this._log(type, finalLogMessage);
   }
 
   private _colorizeText(text: string, color: Colors): string {

--- a/tests/pretty-logs.test.ts
+++ b/tests/pretty-logs.test.ts
@@ -16,10 +16,6 @@ describe("PrettyLogs", () => {
     const logSpy = jest.spyOn(console, "log").mockImplementation();
     const logReturn = logs.ok("This is an OK message");
     expect(logReturn).toBeUndefined();
-
-    // // Debugging: print what was captured
-    // console.log("Captured Logs:", logSpy.mock.calls);
-
     const cleanLogStrings = cleanSpyLogs(logSpy);
     expect(cleanLogStrings).toContain(cleanLogString("✓ This is an OK message"));
   });

--- a/tests/pretty-logs.test.ts
+++ b/tests/pretty-logs.test.ts
@@ -16,6 +16,10 @@ describe("PrettyLogs", () => {
     const logSpy = jest.spyOn(console, "log").mockImplementation();
     const logReturn = logs.ok("This is an OK message");
     expect(logReturn).toBeUndefined();
+
+    // // Debugging: print what was captured
+    // console.log("Captured Logs:", logSpy.mock.calls);
+
     const cleanLogStrings = cleanSpyLogs(logSpy);
     expect(cleanLogStrings).toContain(cleanLogString("✓ This is an OK message"));
   });
@@ -65,10 +69,20 @@ describe("PrettyLogs", () => {
     const logReturn = logs.debug("This is a METADATA message", { thisIsMetadata: true, stuff: Array(5).fill("stuff"), moreStuff: { a: "a", b: "b" } });
     expect(logReturn).toBeUndefined();
     const cleanLogStrings = cleanSpyLogs(logSpy);
-    expect(cleanLogStrings).toEqual([
-      cleanLogString(" ›› This is a METADATA message"),
-      cleanLogString(` ›› ${JSON.stringify({ thisIsMetadata: true, stuff: ["stuff", "stuff", "stuff", "stuff", "stuff"], moreStuff: { a: "a", b: "b" } })}`),
-    ]);
+    expect(cleanLogStrings).toHaveLength(1);
+    const expectedMultilineLog = cleanLogString(
+      ` ›› This is a METADATA message
+      ${JSON.stringify(
+        {
+          thisIsMetadata: true,
+          stuff: ["stuff", "stuff", "stuff", "stuff", "stuff"],
+          moreStuff: { a: "a", b: "b" },
+        },
+        null,
+        2
+      )}`
+    );
+    expect(cleanLogStrings[0]).toEqual(expectedMultilineLog);
   });
 
   it("should log metadata as a string", () => {
@@ -76,7 +90,13 @@ describe("PrettyLogs", () => {
     const logReturn = logs.debug("This is a METADATA message", "This is metadata as a string");
     expect(logReturn).toBeUndefined();
     const cleanLogStrings = cleanSpyLogs(logSpy);
-    expect(cleanLogStrings).toEqual([cleanLogString(" ›› This is a METADATA message"), cleanLogString(" ›› This is metadata as a string")]);
+    expect(cleanLogStrings).toHaveLength(1);
+    const expectedMultilineLog = cleanLogString(
+      ` ›› This is a METADATA message
+      This is metadata as a string`
+    );
+
+    expect(cleanLogStrings[0]).toEqual(expectedMultilineLog);
   });
 
   it("should log an error and stack", () => {
@@ -84,13 +104,13 @@ describe("PrettyLogs", () => {
     const logReturn = logs.debug("This is a METADATA message", { error: tryError() });
     expect(logReturn).toBeUndefined();
     const cleanLogStrings = cleanSpyLogs(logSpy);
+    expect(cleanLogStrings).toHaveLength(1);
+    const [singleLogEntry] = cleanLogStrings;
+    expect(singleLogEntry).toContain("ThisisaMETADATAmessage");
+    expect(singleLogEntry).toContain(`"error":{}`);
 
-    const errorRegex = /↳tryError\(.+\)↳Object.<anonymous>\(/;
+    const errorRegex = /tryError\(.*?\)atObject\.<anonymous>\(/;
 
-    expect(cleanLogStrings).toEqual([
-      cleanLogString(" ›› This is a METADATA message"),
-      cleanLogString(` ›› ${JSON.stringify({ error: {} })}`),
-      expect.stringMatching(errorRegex),
-    ]);
+    expect(singleLogEntry).toMatch(errorRegex);
   });
 });


### PR DESCRIPTION
Resolves #57 

<!--
- You must link the issue number e.g. "Resolves #1234"
- Please do not replace the keyword "Resolves" https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->


Fixes Implemented:
1. Prevents duplicate logs
_logWithStack() previously logged message, metadata, and stack separately, causing redundant entries.
Now, everything is logged in a single structured output.

2. Metadata is correctly formatted
Metadata strings were previously concatenated directly to the message.
Now, metadata appears on a new line, making logs easier to read.

Thanks, Let me know if any changes are needed! 🚀