### PR TITLE
fix: distinguish fatal from error log prefix (#55)

### DIFF
--- a/src/logs.ts
+++ b/src/logs.ts
@@ -145,7 +145,7 @@ export class Logs {
   private _diffColorCommentMessage(type: LogLevelWithOk, message: string) {
     const diffPrefix: Record<LogLevelWithOk, string> = {
       fatal: "> [!CAUTION]",
-      error: "> [!CAUTION]",
+      error: "> [!WARNING]",
       warn: "> [!WARNING]",
       ok: "> [!TIP]",
       info: "> [!NOTE]",


### PR DESCRIPTION
## Summary
Fixes #55 - Change redundant display logs.

\atal\ and \error\ both used \> [!CAUTION]\ prefix. Changed \error\ to use \> [!WARNING]\ to distinguish severity levels.